### PR TITLE
Add JSON reponse for incorrect paths in api/v0

### DIFF
--- a/app/controllers/api/v0/errors_controller.rb
+++ b/app/controllers/api/v0/errors_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V0
+    class ErrorsController < ApplicationController
+      def invalid_path
+        render json: { status: 'error', code: 4000, message: 'path not found' }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     namespace :v0 do
       resources :quotes, only: [:index, :show]
       resources :users, only: [:index, :show]
+      get '*path', to: 'errors#invalid_path'
     end
   end
 end

--- a/spec/controllers/api/v0/errors_controller_spec.rb
+++ b/spec/controllers/api/v0/errors_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Api::V0::ErrorsController, type: :controller do
+  describe 'invalid_path' do
+    it 'renders a json error' do
+      get :invalid_path, format: :json, params: { path: 'fuzzbizz' }
+
+      response_hash = JSON.parse(response.body)
+      expect(response_hash['status']).to eq 'error'
+      expect(response_hash['message']).to eq 'path not found'
+      expect(response_hash['code']).to eq 4000
+    end
+  end
+end

--- a/spec/routing/api/v0/errors_routing_spec.rb
+++ b/spec/routing/api/v0/errors_routing_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Api::V0::ErrorsController, type: :routing do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/api/v0/fizzbuzz')
+        .to route_to('api/v0/errors#invalid_path', format: :json, path: 'fizzbuzz')
+    end
+  end
+end


### PR DESCRIPTION
The JSON API was giving ugly HTML errors on typos, so instead give something machine parseable.